### PR TITLE
Support --max-in-flight/-c in AMQP publishers

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -79,6 +79,7 @@ type Config struct {
 	ConsumerLatency      time.Duration
 	Size                 int
 	Rate                 float32
+	MaxInFlight          int
 	Duration             time.Duration
 	UseMillis            bool
 	QueueDurability      AmqpDurabilityMode

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -103,4 +104,15 @@ func WrappedSequence(len int, start int) []int {
 
 func InjectId(topic string, id int) string {
 	return strings.Replace(topic, "%d", fmt.Sprintf("%d", id), -1)
+}
+
+func Rate(rate float32) string {
+	switch rate {
+	case -1:
+		return "unlimited"
+	case 0:
+		return "idle"
+	default:
+		return strconv.FormatFloat(float64(rate), 'f', -1, 64)
+	}
 }


### PR DESCRIPTION
Since go-amqp doesn't support multiple in-flight
messages, we start a number of Go routines that use the same Sender.